### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Rockstar
+# Rockstar
 
 [![downloads](https://img.shields.io/pypi/dm/rockstar.svg)](https://pypi.python.org/pypi/rockstar/)
 [![version](https://img.shields.io/pypi/v/rockstar.svg)](https://pypi.python.org/pypi/rockstar/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
