### PR TITLE
On Mac version 1.0.1 fail 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click==4.1
-gitpython==1.0.1
+gitpython>=1.0.1


### PR DESCRIPTION
On Mac version 1.0.1 fail on:
 ModuleNotFoundError: No module named 'gittdb.utils.compat'